### PR TITLE
Fixed bugs involving sideNav and the tabs scrollbar

### DIFF
--- a/Gradebook/client/main.css
+++ b/Gradebook/client/main.css
@@ -105,3 +105,13 @@ body {
 .testColumns{
     border-bottom: 1px solid black;
 }
+
+/*To override tab scrolling on x*/
+.tabs{
+    overflow-x: hidden;
+}
+
+/*To fix clickable sideNav above tabs*/
+.button-collapse{
+    width: 50px;
+}


### PR DESCRIPTION
- Fixed bug that cause a scrollbar to appear on the tabs when the gradebook was scrolled all the way to the left and user clicked on furthest tab

- Fixed bug that cause the sideNav to be clickable from above the tabs, and screwing with the sideNav