### PR TITLE
Hamburger icon on navBar, removed fixed sideNav

### DIFF
--- a/Gradebook/client/includes/courseTabs-template.html
+++ b/Gradebook/client/includes/courseTabs-template.html
@@ -14,7 +14,7 @@
 </template>
 
 <template name="tabsContent">
-    <div class="col s12">
+    <div class="col s12" style="margin-top:7px">
         <ul class="tabs">
             <li class="tab col s3">
                 <a class="active" href="#gradeBookChartHolder">Grade Book</a>

--- a/Gradebook/client/includes/nav-template.html
+++ b/Gradebook/client/includes/nav-template.html
@@ -3,6 +3,7 @@
     <nav>
         <div class="nav-wrapper">
             <div class="container">
+                <a href="#" data-activates="slide-out-l" class="button-collapse left"><i class="material-icons">menu</i></a>
                 <a href="#" class="brand-logo">GradeBook</a>
                 <ul id="nav-mobile" class="right hide-on-med-and-down">
                 <!-- Modal Trigger -->

--- a/Gradebook/client/includes/sideNav-template.html
+++ b/Gradebook/client/includes/sideNav-template.html
@@ -1,6 +1,6 @@
 <!--SideNav Structure-->
 <template name="sideNav" class="sideNav">
-    <ul id="slide-out-l" class="side-nav fixed">
+    <ul id="slide-out-l" class="side-nav fixed" style='position: absolute!important'>
         <div class="center-label">
             <h5>My Courses</h5>
         </div>
@@ -18,7 +18,6 @@
             </div>
         {{/if}}
     </ul>
-    <a href="#" data-activates="slide-out-l" class="button-collapse left"><i class="material-icons">menu</i></a>
 </template>
 
 <template name="sideNavDropDown">

--- a/Gradebook/client/main.css
+++ b/Gradebook/client/main.css
@@ -133,7 +133,7 @@ tbody tr td:nth-child(4n+1){
 
 /*To fix clickable sideNav above tabs*/
 .button-collapse{
-    width: 50px;
+    width: 25px;
 }
 
 .settings-nav-wrapper {

--- a/Gradebook/client/main.js
+++ b/Gradebook/client/main.js
@@ -68,7 +68,7 @@ Template.sideNav.helpers({
 });
 
 
-Template.sideNav.onRendered(function () {
+Template.nav.onRendered(function () {
   this.$("[data-activates=slide-out-l]").sideNav({
     // this.$('.button-collapse').sideNav({
     menuWidth: 200, // Default is 300 // Choose the horizontal origin


### PR DESCRIPTION
- The hamburger icon that appears on mobile to open up the sideNav now appears on the navBar, as opposed to the blue hamburger icon below the navBar

- The sideNav no longer scrolls along with the page! The height can be decided later/now/never/5 years ago