### PR TITLE
Completed Assessments UI

### DIFF
--- a/Gradebook/client/includes/assessmentsTab/assessmentsTab.css
+++ b/Gradebook/client/includes/assessmentsTab/assessmentsTab.css
@@ -1,0 +1,38 @@
+.toRight{
+    margin-left: auto;
+}
+
+input{
+    margin: 0!important;
+    height: 1.65rem!important;
+}
+
+.weightingList{
+    box-shadow: none;
+    border: none;
+    cursor: initial;
+}
+
+.weightingListContainer{
+    margin-top: 2.76em;
+    cursor: initial;
+}
+
+.weightingInput{
+    border: 0;
+    cursor: initial;
+}
+
+.addAssessmentButton{
+    height: auto;
+    text-transform: none;
+    line-height: 1.5;
+    padding: 0;
+    font-style: italic;
+    margin-top: 2px;
+    width: 73%;
+}
+
+i.material-icons.toRight:hover{
+    color: red;
+}

--- a/Gradebook/client/includes/assessmentsTab/assessmentsTab.html
+++ b/Gradebook/client/includes/assessmentsTab/assessmentsTab.html
@@ -1,70 +1,132 @@
-<template name = "assessmentsTab">
+<template name="assessmentsTab">
     <h4 class="teal lighten-1 settings-header">Assessments</h4>
-    <div class="row center">
-        <form class="col s12">
-            <div class="row">
-                <div class = "col s4 category offset-s1">
-                    <h5>CourseWork Evaluations (70%)</h5>
-                </div>
-                <div class = "col s4 offset-s1 percentage">
-                    <h5>Final Evaluations (30%)</h5>
-                </div>
+    <form class="col s12">
+        <div class="row">
+            <div class="col s4">
+                <h5>Coursework (<span contenteditable="true"><u>70</u></span>%)</h5>
+                <ul class="collapsible" data-collapsible="expandable">
+                    <li>
+                        <div class="collapsible-header">
+                            <i class="material-icons">book</i>Quizzes
+                            <i class="material-icons toRight" onClick="alert('Where delete stuff will go')">clear</i>
+                        </div>
+                        <div class="collapsible-body">
+                            <span>Quiz 1 - Functions</span>
+                            <br>
+                            <span>Quiz 2 - Vectors</span>
+                            <br>
+                            <span>Quiz 3 - Alternative Math</span>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header">
+                            <i class="material-icons">book</i>Tests
+                            <i class="material-icons toRight" onClick="alert('Where delete stuff will go')">clear</i>
+                        </div>
+                        <div class="collapsible-body">
+                            <span>Test 1 - Chapters 2/3</span>
+                            <br>
+                            <span>Test 2 - Chapters 4/6</span>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header">
+                            <i class="material-icons">book</i>Assignments
+                            <i class="material-icons toRight" onClick="alert('Where delete stuff will go')">clear</i>
+                        </div>
+                        <div class="collapsible-body">
+                            <span>Assignment 1 - Super Math</span>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header" style="cursor: initial">
+                            <i class="material-icons">add_box</i>
+                            <a class="waves-effect waves-teal btn-flat addAssessmentButton">Add assessment type</a>
+                        </div>
+                    </li>
+                </ul>
+
             </div>
-            <div class="row">
-                <div class = "col s3 offset-s1">
-                    <h6><strong>Assessment Type</strong></h6>
-                </div>
-                <div class="col s1">
-                    <h6><strong>Percentage</strong></h6>        
-                </div>
-                <div class = "col s3 offset-s1">
-                    <h6><strong>Assessment Type</strong></h6>
-                </div>
-                <div class="col s1">
-                    <h6><strong>Percentage</strong></h6>        
-                </div>
+            <div class="col s1 weightingListContainer">
+                <ul class="collapsible weightingList" data-collapsible="accordion">
+                    <li>
+                        <div class="collapsible-header weightingInput">
+                            <input id="quizWeight" type="text" value="20">%
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header weightingInput">
+                            <input id="testWeight" type="text" value="30">%
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header weightingInput">
+                            <input id="assignmentWeight" type="text" value="20">%
+                        </div>
+                    </li>
+                </ul>
             </div>
-            <div class="row">
-                <div class = "col s3 offset-s1">
-                    <h6>Quiz</h6>
-                </div>
-                <div class="col s1 inline">
-                        <input id="quizWeight" type="text" placeholder="Quiz Weight">
-                </div>
-                <div class = "col s3 offset-s1">
-                    <h6>Culminating Task</h6>
-                </div>
-                <div class="col s1 inline">
-                        <input id="cptWeight" type="text" placeholder="CPT Weight">
-                </div>
+            <div class="col s2">
             </div>
-            <div class="row">
-                <div class = "col s3 offset-s1">
-                    <h6>Assignment</h6>
-                </div>
-                <div class="col s1 inline">
-                    <input id="assignmentWeight" type="text" placeholder="Assignment Weight">
-                </div>
-                <div class = "col s3 offset-s1">
-                    <h6>Final Exam</h6>
-                </div>
-                <div class="col s1 inline">
-                        <input id="finalExamWeight" type="text" placeholder="Final Exam Weight">
-                </div>
+            <div class="col s4">
+                <h5>Final Evaluations (<span contenteditable="true"><u>30</u></span>%)</h5>
+                <ul class="collapsible" data-collapsible="Expandable">
+                    <li>
+                        <div class="collapsible-header">
+                            <i class="material-icons">book</i>Final Exam
+                            <i class="material-icons toRight" onClick="alert('Where delete stuff will go')">clear</i>
+                        </div>
+                        <div class="collapsible-body">
+                            <span>Super Final Exam</span>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header">
+                            <i class="material-icons">book</i>Culminating
+                            <i class="material-icons toRight" onClick="alert('Where delete stuff will go')">clear</i>
+                        </div>
+                        <div class="collapsible-body">
+                            <span>Part 1 - Design</span>
+                            <br>
+                            <span>Part 2 - Functionality</span>
+                            <br>
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header" style="cursor: initial">
+                            <i class="material-icons">add_box</i>
+                            <a class="waves-effect waves-teal btn-flat addAssessmentButton">Add assessment type</a>
+                        </div>
+                    </li>
+
+                </ul>
             </div>
-            <div class="row">
-                <div class = "col s3 offset-s1">
-                    <h6>Test</h6>
-                </div>
-                <div class="col s1 inline">
-                    <input id="testWeight" type="text" placeholder="Test Weight">
-                </div>
+            <div class="col s1 weightingListContainer">
+                <ul class="collapsible weightingList" data-collapsible="accordion">
+                    <li>
+                        <div class="collapsible-header weightingInput">
+                            <input id="examWeight" type="text" value="20">%
+                        </div>
+                    </li>
+                    <li>
+                        <div class="collapsible-header weightingInput">
+                            <input id="cptWeight" type="text" value="10">%
+                        </div>
+                    </li>
+                </ul>
             </div>
-            <div class="save-category-weightings">
-                <a href="#!" class="waves-effect waves-green btn">Save Changes
-                    <input type="submit" style="display: none" />
-                </a>
-            </div>
-        </form>
-    </div>
+        </div>
+        
+        <div class="save-category-weightings" style="padding-left: 0.75rem">
+            <a href="#!" class="waves-effect waves-green btn">Save Changes
+                <input type="submit" style="display: none" />
+            </a>
+        </div>
+    </form>
+
+    <script>
+        $(document).ready(function () {
+            $('.collapsible').collapsible();
+        });
+    </script>
 </template>


### PR DESCRIPTION
- Left all IDs intact; created the UI that (I hope) was agreed on

- Issues to fix eventually: 
         -> When X is clicked, if the user decides to NOT delete it, it will open up the assessment that was clicked; nothing terrible, but obviously a tad ugly
         -> When assessment tab is expanded, the weightings beneath it do not move down as well. Again, more of a visual issue, will be fixed in time